### PR TITLE
Upgrade Ehcache to version 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
 </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>net.sf.ehcache</groupId>
+      <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hello,

This PR upgrades Ehcache in the project from version 2.x to 3.x. Ehcache 3.x changed artifact's groupId from `net.sf.ehcache` to `org.ehcache` and this is causing issues in projects, where more recent version of Ehcache is already used.