### PR TITLE
#16: supporting ".{format}" placeholders

### DIFF
--- a/src/main/java/ac/simons/oembed/OembedEndpoint.java
+++ b/src/main/java/ac/simons/oembed/OembedEndpoint.java
@@ -272,8 +272,8 @@ public class OembedEndpoint {
 		String uri;
 		final List<NameValuePair> query = new ArrayList<>();
 
-		if (this.getEndpoint().toLowerCase().contains("%{format}")) {
-			uri = this.getEndpoint().replaceAll(Pattern.quote("%{format}"), this.getFormat().toString());
+		if (this.getEndpoint().toLowerCase().contains("{format}")) {
+			uri = this.getEndpoint().replaceAll(Pattern.quote("{format}"), this.getFormat().toString());
 		}
 		else {
 			uri = this.getEndpoint();

--- a/src/test/java/ac/simons/oembed/OembedEndpointTests.java
+++ b/src/test/java/ac/simons/oembed/OembedEndpointTests.java
@@ -98,7 +98,7 @@ public class OembedEndpointTests {
 		assertThat(oembedEndpoint.toApiUrl("https://biking.michael-simons.eu/tracks/1")).hasToString(
 				"https://biking.michael-simons.eu/oembed?format=json&url=https%3A%2F%2Fbiking.michael-simons.eu%2Ftracks%2F1&maxwidth=480&maxheight=360");
 
-		oembedEndpoint.setEndpoint("https://api.twitter.com/1.1/statuses/oembed.%{format}");
+		oembedEndpoint.setEndpoint("https://api.twitter.com/1.1/statuses/oembed.{format}");
 		oembedEndpoint.setFormat(Format.json);
 		oembedEndpoint.setMaxWidth(null);
 		oembedEndpoint.setMaxHeight(null);

--- a/src/test/java/ac/simons/oembed/OembedServiceTests.java
+++ b/src/test/java/ac/simons/oembed/OembedServiceTests.java
@@ -184,7 +184,7 @@ public class OembedServiceTests {
 	@Test
 	public void findEndpointForShouldWork() {
 		OembedEndpoint vimeo = new OembedEndpoint();
-		vimeo.setEndpoint("http://vimeo.com/api/oembed.%{format}");
+		vimeo.setEndpoint("http://vimeo.com/api/oembed.{format}");
 		vimeo.setUrlSchemes(Arrays.asList("https?://vimeo.com/groups/.+/videos/\\d+",
 				"https?://vimeo.com/channels/.+/\\d+", "https?://vimeo.com/\\d+"));
 


### PR DESCRIPTION
@michael-simons

Propose fix for supporting `.{format}` placeholders in oEmbed endpoint URLs